### PR TITLE
Adds functionality to auto pin selected pickables and vehicles

### DIFF
--- a/DiscoveryPins.cs
+++ b/DiscoveryPins.cs
@@ -22,7 +22,7 @@ namespace DiscoveryPins
         public const string PluginName = "DiscoveryPins";
         internal const string Author = "Searica";
         public const string PluginGUID = $"{Author}.Valheim.{PluginName}";
-        public const string PluginVersion = "0.3.3";
+        public const string PluginVersion = "0.3.4";
 
         internal static DiscoveryPins Instance;
         internal static ConfigFile ConfigFile;

--- a/Package/manifest.json
+++ b/Package/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "DiscoveryPins",
   "author": "Searica",
-  "version_number": "0.3.3",
+  "version_number": "0.3.4",
   "website_url": "https://discord.gg/sFmGTBYN6n",
   "description": "QoL Map Pins mod. Customizable pin colors and automatic pinning of things you discover and interact with.",
   "dependencies": [

--- a/Patches/OrePins.cs
+++ b/Patches/OrePins.cs
@@ -61,7 +61,7 @@ namespace DiscoveryPins.Patches
                 return false;
             }
 
-            if (gameObject.GetComponent<Destructible>())
+            if (gameObject.GetComponent<Destructible>() && !gameObject.GetComponent<Pickable>())
             {
                 if (gameObject.TryGetComponent(out HoverText hoverText))
                 {

--- a/Patches/PickablePins.cs
+++ b/Patches/PickablePins.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using DiscoveryPins.Pins;
+using HarmonyLib;
+using UnityEngine;
+using DiscoveryPins.Extensions;
+
+
+namespace DiscoveryPins.Patches
+{
+    [HarmonyPatch]
+    internal static class PickablePins
+    {
+        private static readonly List<string> PickableNames = [
+            "Raspberry",
+            "Blueberry",
+            "Cloudberry",
+            "Carrot",
+            "Onion",
+            "Turnip",
+            "Thistle",
+            "Mushroom",
+            "Barley",
+            "Flax",
+            "Dandelion",
+            "DragonEgg",
+            "Guck", // not pickable per se, but might be pin-worthy
+            //"Flint", // pickable but probably annoying as pin
+            //"Branch", // pickable but probably annoying as pin
+            //"Stone", // pickable but probably annoying as pin
+            //"Pickable" // Fallback probably not necessary
+        ];
+
+        private static readonly Dictionary<string, string> PickablesDict = new Dictionary<string, string>
+        {
+            { "BlueberryBush", "Blueberry" },
+            { "CloudberryBush", "Cloudberry" },
+            { "RaspberryBush", "Raspberry" },
+            { "Pickable_SeedCarrot", "Carrot seeds" },
+            { "Pickable_Carrot", "Carrot" },
+            { "Pickable_SeedOnion", "Onion seeds" },
+            { "Pickable_Onion", "Onion" },
+            { "Pickable_SeedTurnip", "Turnip seeds" },
+            { "Pickable_Turnip", "Turnip" },
+            { "Pickable_Thistle", "Thistle" },
+            { "Pickable_Mushroom_yellow", "Yellow mushroom" },
+            { "Pickable_Mushroom_blue", "Blue mushroom" },
+            { "Pickable_Mushroom", "Mushroom" },
+            { "Pickable_Barley", "Barley" },
+            { "Pickable_Barley_Wild", "Barley" },
+            { "Pickable_Flax", "Flax" },
+            { "Pickable_Flax_Wild", "Flax" },
+            { "Pickable_Dandelion", "Dandelion" },
+            { "Pickable_DragonEgg", "Dragon egg" },
+            { "GuckSack_small", "Guck" },
+            { "GuckSack", "Guck" },
+            //{ "Pickable_Flint", "Flint" },
+            //{ "Pickable_Branch", "Branch" },
+            //{ "Pickable_Stone", "Stone" }
+        };
+
+        private static readonly HashSet<string> PickablePrefabNames = [
+            ];
+
+        /// <summary>
+        ///     Adds AutoPinner to prefab if it is actually Pickable and not already modified.
+        /// </summary>
+        /// <param name="prefab"></param>
+        internal static void TryAddAutoPinnerToPickable(GameObject prefab)
+        {
+            if (IsPickablePrefab(prefab, out string PickableName) && !PickablePrefabNames.Contains(prefab.name))
+            {
+                PickablePrefabNames.Add(prefab.name);
+                AutoPinner.AddAutoPinner(prefab, PickableName, AutoPins.AutoPinCategory.Pickable);
+            }
+        }
+
+
+        /// <summary>
+        ///     Check if it is an Pickable prefab and get Pickable name
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="PickableName"></param>
+        /// <returns></returns>
+        private static bool IsPickablePrefab(GameObject gameObject, out string PickableName)
+        {
+            bool isPickablePrefab = false;
+            PickableName = null;
+            foreach (var name in PickablesDict.Keys)
+            {
+                if (gameObject.name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    PickablesDict.TryGetValue(name, out PickableName);
+                    isPickablePrefab = true;
+                    break;
+                }
+            }
+
+            return isPickablePrefab;
+        }
+    }
+}

--- a/Patches/PickablePins.cs
+++ b/Patches/PickablePins.cs
@@ -4,6 +4,8 @@ using DiscoveryPins.Pins;
 using HarmonyLib;
 using UnityEngine;
 using DiscoveryPins.Extensions;
+using System.Linq;
+using static Mono.Security.X509.X520;
 
 
 namespace DiscoveryPins.Patches
@@ -86,14 +88,11 @@ namespace DiscoveryPins.Patches
         {
             bool isPickablePrefab = false;
             PickableName = null;
-            foreach (var name in PickablesDict.Keys)
+
+            if (PickablesDict.Keys.Contains(gameObject.name, StringComparer.OrdinalIgnoreCase))
             {
-                if (gameObject.name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                {
-                    PickablesDict.TryGetValue(name, out PickableName);
-                    isPickablePrefab = true;
-                    break;
-                }
+                PickablesDict.TryGetValue(gameObject.name, out PickableName);
+                isPickablePrefab = true;
             }
 
             return isPickablePrefab;

--- a/Patches/VehiclePins.cs
+++ b/Patches/VehiclePins.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using DiscoveryPins.Pins;
+using HarmonyLib;
+using UnityEngine;
+using DiscoveryPins.Extensions;
+
+
+namespace DiscoveryPins.Patches
+{
+    [HarmonyPatch]
+    internal static class VehiclePins
+    {
+        private static readonly List<string> VehicleNames = [
+            "Cart",
+            "Raft",
+            "Karve",
+            "VikingShip_Ashlands", // Drakkar
+            "VikingShip", //Longship
+            "Trailership", // Trailer Ship
+        ];
+
+        private static readonly Dictionary<string, string> VehiclesDict = new Dictionary<string, string> {
+            {"Cart", "Cart"},
+            {"Raft", "Raft"},
+            {"Karve", "Karve" },
+            {"VikingShip_Ashlands", "Drakkar" },
+            {"VikingShip", "Longship" },
+            {"Trailership", "Trailer Ship" }
+        };
+
+
+        private static readonly HashSet<string> VehiclePrefabNames = [
+            ];
+
+        /// <summary>
+        ///     Adds AutoPinner to prefab if it is actually a vehicle and not already modified.
+        /// </summary>
+        /// <param name="prefab"></param>
+        internal static void TryAddAutoPinnerToVehicle(GameObject prefab)
+        {
+            if (IsVehiclePrefab(prefab, out string VehicleName) && !VehiclePrefabNames.Contains(prefab.name))
+            {
+                VehiclePrefabNames.Add(prefab.name);
+                AutoPinner.AddAutoPinner(prefab, VehicleName, AutoPins.AutoPinCategory.Vehicle);
+            }
+        }
+
+
+        /// <summary>
+        ///     Check if it is a vehicle prefab and get vehicle name
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <param name="VehicleName"></param>
+        /// <returns></returns>
+        private static bool IsVehiclePrefab(GameObject gameObject, out string VehicleName)
+        {
+            bool isVehiclePrefab = false;
+            VehicleName = null;
+            foreach (var name in VehiclesDict.Keys)
+            {
+                if (gameObject.name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    VehiclesDict.TryGetValue(name, out VehicleName);
+                    isVehiclePrefab = true;
+                    break;
+                }
+            }
+
+            return isVehiclePrefab;
+        }
+    }
+}

--- a/Patches/VehiclePins.cs
+++ b/Patches/VehiclePins.cs
@@ -4,6 +4,7 @@ using DiscoveryPins.Pins;
 using HarmonyLib;
 using UnityEngine;
 using DiscoveryPins.Extensions;
+using System.Linq;
 
 
 namespace DiscoveryPins.Patches
@@ -57,14 +58,11 @@ namespace DiscoveryPins.Patches
         {
             bool isVehiclePrefab = false;
             VehicleName = null;
-            foreach (var name in VehiclesDict.Keys)
+
+            if (VehiclesDict.Keys.Contains(gameObject.name, StringComparer.OrdinalIgnoreCase))
             {
-                if (gameObject.name.Equals(name, StringComparison.OrdinalIgnoreCase))
-                {
-                    VehiclesDict.TryGetValue(name, out VehicleName);
-                    isVehiclePrefab = true;
-                    break;
-                }
+                VehiclesDict.TryGetValue(gameObject.name, out VehicleName);
+                isVehiclePrefab = true;
             }
 
             return isVehiclePrefab;

--- a/Patches/ZoneSystemPatches.cs
+++ b/Patches/ZoneSystemPatches.cs
@@ -33,6 +33,8 @@ namespace DiscoveryPins.Patches
 
                 OrePins.TryAddAutoPinnerToOre(prefab);
                 PortalPins.TryAddAutoPinnerToPortal(prefab);
+                PickablePins.TryAddAutoPinnerToPickable(prefab);
+                VehiclePins.TryAddAutoPinnerToVehicle(prefab);
             }
         }
     }

--- a/Pins/AutoPins.cs
+++ b/Pins/AutoPins.cs
@@ -10,7 +10,9 @@ namespace DiscoveryPins.Pins
             Dungeon,
             Location,
             Ore,
-            Portal
+            Portal,
+            Pickable,
+            Vehicle
         }
 
         internal static Dictionary<AutoPinCategory, PinType> DefaultPinTypes = new()
@@ -18,7 +20,9 @@ namespace DiscoveryPins.Pins
             { AutoPinCategory.Dungeon, PinType.Icon4 }, // Cave
             { AutoPinCategory.Location, PinType.Icon0  }, // Fireplace
             { AutoPinCategory.Ore, PinType.Icon2 }, // Hammer
-            { AutoPinCategory.Portal, PinType.Icon3 } // Ball
+            { AutoPinCategory.Portal, PinType.Icon3 }, // Ball
+            { AutoPinCategory.Pickable, PinType.Icon3 }, // Ball
+            { AutoPinCategory.Vehicle, PinType.Icon3 } // Ball
         };     
     }
 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.3")]
-[assembly: AssemblyFileVersion("0.3.3")]
+[assembly: AssemblyVersion("0.3.4")]
+[assembly: AssemblyFileVersion("0.3.4")]

--- a/Publish/ThunderStore/manifest.json
+++ b/Publish/ThunderStore/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "DiscoveryPins",
   "author": "Searica",
-  "version_number": "0.3.3",
+  "version_number": "0.3.4",
   "website_url": "https://discord.gg/sFmGTBYN6n",
   "description": "QoL Map Pins mod. Customizable pin colors and automatic pinning of things you discover and interact with.",
   "dependencies": [


### PR DESCRIPTION
Changes are supposed to make vehicles (cart, karve, longship, drakkar) and various pickables (plus one exception for Guck) pinnable by using the autopin key combination.

Adds AutoPinCategories 'Pickable' and 'Vehicle', using the default Icon3 alias 'ball'.
No changes to colorings.

Since I don't know all parts of the components, I used a dictionary to provide each supported prefab name with a pin label.
Could have just checked if the prefab.name is contained in the dict.keys instead of keeping the foreach structure though.

I tested and could pin things like raspberry bushes, mushrooms, blueberry bushes, thistles, dandelions with LeftShift + Mouse1
It didn't pin the excluded things like branch, flints and stones.

I noticed that if I hit a raspberry bush with a fist then it would also be pinned, probably because it was mistaken for an ore, because of the destructible component, so I'd suggest adding another commit to expand that gameObject's condition not also having the pickable component.